### PR TITLE
Include <cups/sidechannel.h>

### DIFF
--- a/rastertoadafruitmini.cpp
+++ b/rastertoadafruitmini.cpp
@@ -1,3 +1,4 @@
+#include <cups/sidechannel.h>
 #include <cups/raster.h>
 
 #include <iostream>


### PR DESCRIPTION
When building against cups 2.3.0 <cups/sidechannel.h> must be added explicility.